### PR TITLE
Fix python2 build, allow pure python3 build for rhel8, update packages

### DIFF
--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -8,15 +8,15 @@ set -eo pipefail
 
 # Ensure we are using the latest pip and wheel packages.
 
-pip3 install -U pip setuptools wheel
+pip install -U pip setuptools wheel
 
 # Install mod_wsgi for use in optional webdav support.
 
-pip3 install 'mod_wsgi==4.6.5'
+pip install 'mod_wsgi==4.6.5'
 
 # Install base packages needed for running Jupyter Notebooks. 
 
-pip3 install -r /tmp/src/requirements.txt
+pip install -r /tmp/src/requirements.txt
 
 # Activate JupyterHub extension for JupyterLab.
 
@@ -49,7 +49,7 @@ echo "source /opt/app-root/etc/generate_container_user" >> /opt/app-root/etc/scl
 # Set home and install supervisor
 
 HOME=/opt/app-root
-pip3 install --no-cache-dir supervisor==4.0.*
+pip install --no-cache-dir supervisor==4.0.*
 
 # Remove the per user Python area and cache as shouldn't need them now.
 

--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -15,18 +15,16 @@ pip install -U pip setuptools wheel
 pip install 'mod_wsgi==4.6.5'
 
 # Install base packages needed for running Jupyter Notebooks. 
+pip install -r /tmp/src/requirements.txt
 
-if hash python3 2>/dev/null; then
-    pip install -r /tmp/src/requirements.txt
-    # Activate JupyterHub extension for JupyterLab.
-    # The hub extension install fails for python2
+#if hash python3 2>/dev/null; then
+#    # Activate JupyterHub extension for JupyterLab.
+#    # The hub extension install fails for python2
     jupyter labextension install @jupyterlab/hub-extension
     npm cache clean --force
     rm -rf $HOME/.cache/yarn
     rm -rf $HOME/.node-gyp
-else
-    pip install -r /tmp/src/requirements_python2.txt
-fi
+#fi
 
 # Copy into place default config files for Jupyter and Apache webdav.
 

--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -8,19 +8,19 @@ set -eo pipefail
 
 # Ensure we are using the latest pip and wheel packages.
 
-pip install -U pip setuptools wheel
+pip3 install -U pip setuptools wheel
 
 # Install mod_wsgi for use in optional webdav support.
 
-pip install 'mod_wsgi==4.6.5'
+pip3 install 'mod_wsgi==4.6.5'
 
 # Install base packages needed for running Jupyter Notebooks. 
 
-pip install -r /tmp/src/requirements.txt
+pip3 install -r /tmp/src/requirements.txt
 
 # Activate JupyterHub extension for JupyterLab.
 
-jupyter labextension install @jupyterlab/hub-extension@^0.12.0
+jupyter labextension install @jupyterlab/hub-extension
 npm cache clean --force
 rm -rf $HOME/.cache/yarn
 rm -rf $HOME/.node-gyp
@@ -35,72 +35,21 @@ cp /tmp/src/httpd-webdav.conf /opt/app-root/etc/
 # For when running the image, or using it as a S2I builder, we use a second
 # set of custom S2I scripts. We now need to move these into the correct
 # location and have the custom image use those by dropping in an image
-# metadata file which overrides the labels of the base image.
+# meta file which overrides the labels of the base image.
 
 mkdir -p /tmp/.s2i
-
 mv /tmp/src/builder/image_metadata.json /tmp/.s2i/image_metadata.json
-
 mv /tmp/src/builder /opt/app-root/builder
-
 mv /tmp/src/*.sh /opt/app-root/bin
 
 # Ensure passwd/group file intercept happens for any shell environment.
 
 echo "source /opt/app-root/etc/generate_container_user" >> /opt/app-root/etc/scl_enable
 
-# Create additional directories.
-
-echo " -----> Creating additional directories."
-
-mkdir -p /opt/app-root/data
-
-########################################################################
-# WARNING: The following series of steps install supervisord using the
-# system Python, not SCL Python. Always put stuff that needs to be done
-# using the SCL Python above this line as the steps below will fiddle
-# with the environment so that SCL Python isn't used.
-########################################################################
-
-# Override PATH for the assemble script so that /usr/bin precedes
-# /opt/app-root/bin so wrong Python version isn't found during setup
-# if using Python S2I base image.
-
-PATH=/usr/bin:$PATH
-
-# Override HOME directory for the assemble script so that per user
-# files are not installed under /opt/app-root/src. This means that
-# the per user Python area is located under /opt/app-root/.local.
+# Set home and install supervisor
 
 HOME=/opt/app-root
-
-# Install pip for Python 2.7.
-
-curl -s -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
-
-/usr/bin/python /tmp/get-pip.py --user
-
-rm -f /tmp/get-pip.py
-
-# Install virtualenv for Python 2.7.
-
-/opt/app-root/.local/bin/pip install --no-cache-dir --user virtualenv
-
-# Create a virtual environment for Python 2.7.
-
-/opt/app-root/.local/bin/virtualenv /opt/app-root/supervisor
-
-# Install supervisor into the virtual environment.
-
-source /opt/app-root/supervisor/bin/activate
-
-pip install --no-cache-dir 'supervisor<3.4.0'
-
-# Link supervisorctl into /opt/app-root/bin so in PATH.
-
-mkdir -p /opt/app-root/bin
-
-ln -s /opt/app-root/supervisor/bin/supervisorctl /opt/app-root/bin/supervisorctl
+pip3 install --no-cache-dir supervisor==4.0.*
 
 # Remove the per user Python area and cache as shouldn't need them now.
 
@@ -108,6 +57,7 @@ rm -rf /opt/app-root/.local /opt/app-root/.cache
 
 # Generate default supervisord.conf file.
 
+mkdir /opt/app-root/supervisor
 echo_supervisord_conf | \
     sed -e 's%^logfile=/tmp/supervisord.log%logfile=/dev/fd/1%' \
         -e 's%^logfile_maxbytes=50MB%logfile_maxbytes=0%' > \
@@ -141,10 +91,6 @@ autostart=%(ENV_JUPYTER_ENABLE_WEBDAV)s
 [include]
 files = /opt/app-root/src/.supervisord/*.conf
 EOF
-
-########################################################################
-# WARNING: Don't do anything beyond this point that relies on Python.
-########################################################################
 
 # Make sure the S2I source directory is empty as we will use the image
 # produced to run further S2I builds.

--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -16,14 +16,17 @@ pip install 'mod_wsgi==4.6.5'
 
 # Install base packages needed for running Jupyter Notebooks. 
 
-pip install -r /tmp/src/requirements.txt
-
-# Activate JupyterHub extension for JupyterLab.
-
-jupyter labextension install @jupyterlab/hub-extension
-npm cache clean --force
-rm -rf $HOME/.cache/yarn
-rm -rf $HOME/.node-gyp
+if hash python3 2>/dev/null; then
+    pip install -r /tmp/src/requirements.txt
+    # Activate JupyterHub extension for JupyterLab.
+    # The hub extension install fails for python2
+    jupyter labextension install @jupyterlab/hub-extension
+    npm cache clean --force
+    rm -rf $HOME/.cache/yarn
+    rm -rf $HOME/.node-gyp
+else
+    pip install -r /tmp/src/requirements_python2.txt
+fi
 
 # Copy into place default config files for Jupyter and Apache webdav.
 

--- a/minimal-notebook/builder/run
+++ b/minimal-notebook/builder/run
@@ -54,7 +54,7 @@ if [[ ! -z "${JUPYTER_ENABLE_SUPERVISORD}" ]]; then
     # Startup supervisord against the configuration and keep it in the
     # foreground so becomes process ID 1 for the container.
 
-    exec /opt/app-root/supervisor/bin/supervisord --nodaemon \
+    exec supervisord --nodaemon \
 	--configuration $SUPERVISORD_CONF
 else
     . /opt/app-root/bin/start-notebook.sh

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -3,5 +3,5 @@ jupyterhub==1.0.0
 jupyterlab==0.35.6
 jupyter_kernel_gateway==2.3.0
 dask==1.2.2
-distributed==1.28.1
+distributed==1.28.1 # sudo dnf install redhat-rpm-config python2-devel
 tornado<6.0.0

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -1,7 +1,7 @@
-notebook==5.7.4
-jupyterhub==0.9.4
+notebook==5.7.8
+jupyterhub==1.0.0
 jupyterlab==0.35.6
-jupyter_kernel_gateway==2.2.0
-dask==1.1.1
-distributed==1.26.0
+jupyter_kernel_gateway==2.3.0
+dask==1.2.2
+distributed==1.28.1
 tornado<6.0.0

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -1,5 +1,5 @@
 notebook==5.7.8
-jupyterhub==1.0.0
+jupyterhub==0.9.4;python_version>"3.3"
 jupyterlab==0.35.6
 jupyter_kernel_gateway==2.3.0
 dask==1.2.2

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -1,6 +1,6 @@
 notebook==5.7.4
 jupyterhub==0.9.4
-jupyterlab==0.35.4
+jupyterlab==0.35.6
 jupyter_kernel_gateway==2.2.0
 dask==1.1.1
 distributed==1.26.0

--- a/minimal-notebook/requirements_python2.txt
+++ b/minimal-notebook/requirements_python2.txt
@@ -1,7 +1,0 @@
-notebook==5.7.8
-#jupyterhub is not compatible
-jupyterlab==0.33.12 # later versions drop python2 support
-jupyter_kernel_gateway==2.3.0
-dask==1.2.2
-distributed==1.28.1 # sudo dnf install redhat-rpm-config python2-devel
-tornado<6.0.0

--- a/minimal-notebook/requirements_python2.txt
+++ b/minimal-notebook/requirements_python2.txt
@@ -1,0 +1,7 @@
+notebook==5.7.8
+#jupyterhub is not compatible
+jupyterlab==0.33.12 # later versions drop python2 support
+jupyter_kernel_gateway==2.3.0
+dask==1.2.2
+distributed==1.28.1 # sudo dnf install redhat-rpm-config python2-devel
+tornado<6.0.0


### PR DESCRIPTION
Update everything to python3 and do not use python2 in any way. This greatly simplifies the assemble script and makes it ready for rhel8/centos8 python36 containers which ship only python3. Furthermore Python2 is EOL 2020.