### PR TITLE
Add jupyter-tensorboard extension

### DIFF
--- a/tensorflow-notebook/.s2i/bin/assemble
+++ b/tensorflow-notebook/.s2i/bin/assemble
@@ -31,6 +31,8 @@ cd $HOME
 
 rm -rf /tmp/facets
 
+jupyter tensorboard enable --sys-prefix
+
 # Import matplotlib the first time to build the font cache.
 
 MPLBACKEND=Agg python -c "import matplotlib.pyplot"

--- a/tensorflow-notebook/requirements.txt
+++ b/tensorflow-notebook/requirements.txt
@@ -28,3 +28,4 @@ xlrd==1.2.*
 
 tensorflow==1.11.*
 keras==2.2.*
+jupyter-tensorboard==0.1.10


### PR DESCRIPTION
Extension jupyter-tensorboard allows users of Jupyter(Hub) to run and access Tensorboard easily from the JupyterHub interface.

See the documentation at https://pypi.org/project/jupyter-tensorboard/