### PR TITLE
Jupyterlab1.0

### DIFF
--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -11,19 +11,6 @@ set -eo pipefail
 pip install -U pip setuptools wheel
 pip install -r /tmp/src/requirements.txt
 
-# Activate JupyterHub extension for JupyterLab.
-
-function module_installed() {
-    python -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader('$1') else 1)"
-}
-
-if module_installed 'jupyterhub' && module_installed 'jupyterlab'; then
-    jupyter labextension install @jupyterlab/hub-extension
-    npm cache clean --force
-    rm -rf $HOME/.cache/yarn
-    rm -rf $HOME/.node-gyp
-fi
-
 # Copy into place default config files for Jupyter and Apache webdav.
 
 cp /tmp/src/jupyter_notebook_config.py /opt/app-root/etc/

--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -9,7 +9,13 @@ set -eo pipefail
 # Ensure we are using the latest pip and wheel packages.
 
 pip install -U pip setuptools wheel
+
+# Install packages and clean up npm cache
 pip install -r /tmp/src/requirements.txt
+npm cache clean --force
+rm -rf $HOME/.cache/yarn
+rm -rf $HOME/.node-gyp
+
 
 # Copy into place default config files for Jupyter and Apache webdav.
 

--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -9,17 +9,6 @@ set -eo pipefail
 # Ensure we are using the latest pip and wheel packages.
 
 pip install -U pip setuptools wheel
-
-# Install mod_wsgi for use in optional webdav support.
-
-pip install 'mod_wsgi==4.6.5'
-
-# Install supervisord for managing multiple applications.
-
-pip install 'supervisor==4.0.2'
-
-# Install base packages needed for running Jupyter Notebooks. 
-
 pip install -r /tmp/src/requirements.txt
 
 # Activate JupyterHub extension for JupyterLab.

--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -8,10 +8,10 @@ set -eo pipefail
 
 # Ensure we are using the latest pip and wheel packages.
 
-pip install -U pip setuptools wheel
+pip install -U pip setuptools wheel --no-cache-dir
 
 # Install packages and clean up npm cache
-pip install -r /tmp/src/requirements.txt
+pip install -r /tmp/src/requirements.txt --no-cache-dir
 npm cache clean --force
 rm -rf $HOME/.cache/yarn
 rm -rf $HOME/.node-gyp

--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -16,7 +16,6 @@ npm cache clean --force
 rm -rf $HOME/.cache/yarn
 rm -rf $HOME/.node-gyp
 
-
 # Copy into place default config files for Jupyter and Apache webdav.
 
 cp /tmp/src/jupyter_notebook_config.py /opt/app-root/etc/

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -1,6 +1,6 @@
 notebook==5.7.8
 jupyterhub==0.9.6;python_version>"2.7"
-jupyterlab==0.35.6;python_version>"2.7"
+jupyterlab==1.0.*;python_version>"2.7"
 jupyter_kernel_gateway==2.3.0
 dask==1.2.2
 distributed==1.28.1

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -1,3 +1,10 @@
+# Install mod_wsgi for use in optional webdav support.
+mod_wsgi==4.6.7
+
+# Install supervisord for managing multiple applications.
+supervisor==4.0.3
+
+# Install base packages needed for running Jupyter Notebooks.
 notebook==5.7.8
 jupyterhub==0.9.6;python_version>"2.7"
 jupyterlab==1.0.*;python_version>"2.7"

--- a/scipy-notebook/.s2i/bin/assemble
+++ b/scipy-notebook/.s2i/bin/assemble
@@ -14,8 +14,8 @@ jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
 # Also activate ipywidgets/bokeh extension for JupyterLab.
 
-jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.38.1
-jupyter labextension install jupyterlab_bokeh@0.6.3
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install jupyterlab_bokeh
 
 # Install facets which does not have a pip package.
 

--- a/tensorflow-notebook/.s2i/bin/assemble
+++ b/tensorflow-notebook/.s2i/bin/assemble
@@ -14,8 +14,8 @@ jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
 # Also activate ipywidgets/bokeh extension for JupyterLab.
 
-jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.38.1
-jupyter labextension install jupyterlab_bokeh@0.6.3
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install jupyterlab_bokeh
 
 # Install facets which does not have a pip package.
 


### PR DESCRIPTION
Update to jupyterlab 1.0.0
JupyterLab now has a File > Logout menu entry when running with JupyterHub.

https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/getting_started/changelog.rst#jupyterhub-integration says "We now include the JupyterHub extension in core JupyterLab, so you no longer need to install @jupyterlab/hub-extension. (#6451, #6428) "